### PR TITLE
Replace list-all command pipeline with just awk

### DIFF
--- a/bin/list-all
+++ b/bin/list-all
@@ -1,2 +1,2 @@
 #!/bin/bash
-echo $(git ls-remote -t https://github.com/nim-lang/Nim.git | awk '{print $2}' | cut -d/ -f3 | grep -v '{}' | sort -t. -n -k2,3)
+echo $(git ls-remote -t https://github.com/nim-lang/Nim.git | awk '$0 !~ "{}" { split($2, subfield, "/"); print subfield[3] }' | sort -t. -n -k2,3)


### PR DESCRIPTION
Clean up the `list-all` command to only use `awk` and `sort`.

The current command uses `awk`, `grep`, `cut`, and `sort`. `awk` can do most of the things `grep` and `cut` were providing, so a simpler command is better