### PR TITLE
Add nim tools install step

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -14,3 +14,4 @@ cd .. || exit 1
 bin/nim c koch
 ./koch boot -d:release
 ./koch nimble
+./koch tools


### PR DESCRIPTION
Add a step to install that calls `koch tools`, installing the nimgrep, nimsuggest, and nimpretty tools that come bundled with vim.

Some editor plugins rely on nimsuggest being present for their autocomplete, and nimpretty for their code cleanup.