### PR TITLE
Update install script to install Nim 1.0.2+

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -1,29 +1,12 @@
 #!/bin/sh
 # instructions taken straight from nim github README
-if [ "$ASDF_INSTALL_TYPE" = "version" ]
-then
-	git clone --depth 1 -b "$ASDF_INSTALL_VERSION" https://github.com/nim-lang/Nim.git "$ASDF_INSTALL_PATH"
-else
-	git clone --depth 1 "$ASDF_INSTALL_VERSION" "$ASDF_INSTALL_PATH"
-fi
+
+NIM_REPOSITORY="https://github.com/nim-lang/Nim.git"
+
+git clone --depth 1 --single-branch -b v"$ASDF_INSTALL_VERSION" "$NIM_REPOSITORY" "$ASDF_INSTALL_PATH"
+
 cd "$ASDF_INSTALL_PATH" || exit 1
 
-if [ -f "./build_all.sh" ]
-then
-	sh ./build_all.sh
-else
-	git clone --depth 1 -b "$ASDF_INSTALL_VERSION" https://github.com/nim-lang/csources.git
-	# if csources is not tagged, fall back to .0 version:
-	if [ $? -ne 0 ]; then
-		DOTZERO_VERSION="`echo $ASDF_INSTALL_VERSION | sed -e 's/[0-9]*$/0/'`"
-		git clone --depth 1 -b "$DOTZERO_VERSION" https://github.com/nim-lang/csources.git
-	fi
+cd "$ASDF_INSTALL_PATH" || exit 1
 
-	cd csources || exit 1
-	sh build.sh
-	cd .. || exit 1
-	bin/nim c koch
-	./koch boot -d:release
-	./koch nimble
-	./koch tools
-fi
+sh build_all.sh || exit 1

--- a/bin/install
+++ b/bin/install
@@ -1,8 +1,8 @@
 #!/bin/sh
-# instructions taken straight from nim github README
+# Instructions taken straight from nim github README
 
 NIM_REPOSITORY="https://github.com/nim-lang/Nim.git"
-VERSION="v${ASDF_INSTALL_VERSION}"
+VERSION="v$(echo $ASDF_INSTALL_VERSION | tr --delete v)"
 
 if [ "$ASDF_INSTALL_TYPE" = "version" ]
 then

--- a/bin/install
+++ b/bin/install
@@ -2,11 +2,18 @@
 # instructions taken straight from nim github README
 
 NIM_REPOSITORY="https://github.com/nim-lang/Nim.git"
+VERSION="v${ASDF_INSTALL_VERSION}"
 
-git clone --depth 1 --single-branch -b v"$ASDF_INSTALL_VERSION" "$NIM_REPOSITORY" "$ASDF_INSTALL_PATH"
+if [ "$ASDF_INSTALL_TYPE" = "version" ]
+then
+  git clone --depth 1 --single-branch -b "$VERSION" "$NIM_REPOSITORY" "$ASDF_INSTALL_PATH"
+fi
 
 cd "$ASDF_INSTALL_PATH" || exit 1
 
-cd "$ASDF_INSTALL_PATH" || exit 1
-
-sh build_all.sh || exit 1
+if [ -f "./build_all.sh" ]
+then
+  sh ./build_all.sh || exit 1
+else
+  exit 1
+fi

--- a/bin/list-all
+++ b/bin/list-all
@@ -1,2 +1,2 @@
 #!/bin/bash
-echo $(git ls-remote -t https://github.com/nim-lang/Nim.git | awk '$0 !~ "{}" { split($2, subfield, "/"); print subfield[3] }' | sort -V)
+echo $(git ls-remote -t https://github.com/nim-lang/Nim.git | awk '$0 !~ "{}" { split($2, subfield, "/"); print subfield[3] }' | sort -V) | tr --delete v


### PR DESCRIPTION
The installation method for Nim 1.0,2+ is a little different from versions 1.0.0 and below. This new installation script addresses this need.